### PR TITLE
add name option to CLI

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftPM",
+        "repositoryURL": "https://github.com/apple/swift-package-manager.git",
+        "state": {
+          "branch": null,
+          "revision": "235aacc514cb81a6881364b0fedcb3dd083228f3",
+          "version": "0.3.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -13,11 +13,13 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.3.0"),
+
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(name: "TranscribeCLI", dependencies: ["Transcribe"]),
+        .target(name: "TranscribeCLI", dependencies: ["Transcribe", "Utility"]),
         .target(name: "Transcribe", dependencies: []),
         .testTarget(name: "TranscribeTests", dependencies: ["Transcribe"])
     ]

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The command line tool takes an input file and converts it to Markdown and WebVTT
 Usage:
 
 ```sh
-swift run -c release TranscribeCLI transcript.json
+swift run -c release TranscribeCLI --json transcript.json
 ```
 
 This will produce an `transcript.md` file in the current directory.

--- a/Sources/TranscribeCLI/main.swift
+++ b/Sources/TranscribeCLI/main.swift
@@ -3,42 +3,56 @@
 ///
 /// Usage:
 ///
-///     TranscribeCLI FILE
+///     TranscribeCLI --json FILE
+///     TranscribeCLI --json FILE --names SPEAKER SPEAKER
 ///
 ///     FILE: The input file. Must be in Amazon Transcribe JSON format.
+///     SPEAKER: Name of the speaker. Should be ordered by appearance.
 ///
 ///     The resulting Markdown and WebVTT file is saved to the current directory with the
 ///     same basename as the input file.
 
 import Foundation
 import Transcribe
-
-struct TranscribeCLIError: Error {
-    var code: Int
-    var message: String
-
-    static let missingArgument = TranscribeCLIError(code: 1, message: "Usage: \(CommandLine.arguments[0]) FILE")
-    static func argumentIsNotAFile(argument: String) -> TranscribeCLIError {
-        return TranscribeCLIError(code: 2, message: "\(argument) must be a file")
-    }
-}
+import Utility
 
 // MARK: - Main program
 
 do {
-    guard CommandLine.arguments.count == 2 else {
-        throw TranscribeCLIError.missingArgument
+    // setup the argument parser
+    let parser = ArgumentParser(usage: "<options>",
+                                overview: "A Swift parser for output files from automated transcription services.")
+    let rawInputFilename = parser.add(option: "--json", shortName: "-j", kind: PathArgument.self, usage: "Amazon transcribe json file, e.g. './TestFixtures/amazon-transcribe-swift-community-podcast-0001-formatted-short.json'")
+    let rawSpeakerNames = parser.add(option: "--names", shortName: "-n", kind: [String].self, usage: "Array of speaker names, e.g. 'alice bob'")
+    
+    // The first argument is always the executable, drop it
+    let arguments = Array(ProcessInfo.processInfo.arguments.dropFirst())
+    let parsedArguments = try parser.parse(arguments)
+    guard let inputFilename = parsedArguments.get(rawInputFilename),
+        inputFilename.path.asString.lowercased().hasSuffix("json") else {
+        throw ArgumentParserError.invalidValue(argument: "--json", error: ArgumentConversionError.custom("No json file specified"))
+    }
+   
+    // validate json filename
+    let inputFile = URL(fileURLWithPath: inputFilename.path.asString).standardizedFileURL
+    guard let isRegularFile = try? inputFile.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile, isRegularFile == true else {
+        throw ArgumentParserError.invalidValue(argument: "--json", error: ArgumentConversionError.custom("File not found"))
     }
 
-    let inputFilename = CommandLine.arguments[1]
-    let inputFile = URL(fileURLWithPath: inputFilename).standardizedFileURL
-    guard let isRegularFile = try inputFile.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile, isRegularFile == true else {
-        throw TranscribeCLIError.argumentIsNotAFile(argument: inputFile.path)
-    }
-
-    let transcript = try AmazonTranscribe.Transcript(file: inputFile)
+    // parse the amazon transcription json file
+    var transcript = try AmazonTranscribe.Transcript(file: inputFile)
     let outputDirectory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
 
+    // Set speaker names
+    if let speakerNames = parsedArguments.get(rawSpeakerNames),
+        speakerNames.count == transcript.speakers.count {
+        for (index, speaker) in transcript.speakers.enumerated() {
+            transcript[speaker: speaker.speakerLabel]?.name = speakerNames[index]
+        }
+    } else {
+        throw ArgumentParserError.invalidValue(argument: "--names", error: ArgumentConversionError.custom("Wrong number of speaker names (should be \(transcript.speakers.count))"))
+    }
+    
     // write markdown file
     let markdown = transcript.makeMarkdown()
     let markdownOutputFilename = inputFile.deletingPathExtension().appendingPathExtension("md").lastPathComponent
@@ -51,9 +65,8 @@ do {
     let webvttOutputFile = outputDirectory.appendingPathComponent(webvttOutputFilename)
     try Data(webvtt.utf8).write(to: webvttOutputFile)
 
-} catch let error as TranscribeCLIError {
-    print("Error: \(error.message) (\(error.code))", to: &stdError)
-    exit(Int32(error.code))
+} catch let error as ArgumentParserError {
+    print(error.description)
 } catch {
     print("Error: \(error)", to: &stdError)
     exit(-1)

--- a/Sources/TranscribeCLI/main.swift
+++ b/Sources/TranscribeCLI/main.swift
@@ -44,13 +44,15 @@ do {
     let outputDirectory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
 
     // Set speaker names
-    if let speakerNames = parsedArguments.get(rawSpeakerNames),
-        speakerNames.count == transcript.speakers.count {
-        for (index, speaker) in transcript.speakers.enumerated() {
-            transcript[speaker: speaker.speakerLabel]?.name = speakerNames[index]
+    if let speakerNames = parsedArguments.get(rawSpeakerNames) {
+        // Counts of names passed on CLI and speakers in Transcript do not match => print warning
+        if speakerNames.count != transcript.speakers.count {
+            print("Warning: Number of speaker names passed in (\(speakerNames.count)) does not match the number of speakers in the transcript (\(transcript.speakers.count) – \(transcript.speakers.map { $0.speakerLabel }))", to: &stdError)
         }
-    } else {
-        throw ArgumentParserError.invalidValue(argument: "--names", error: ArgumentConversionError.custom("Wrong number of speaker names (should be \(transcript.speakers.count))"))
+        
+        for (speakerName, speakerIndex) in zip(speakerNames, transcript.speakers.indices) {
+            transcript.speakers[speakerIndex].name = speakerName
+        }
     }
     
     // write markdown file

--- a/Sources/TranscribeCLI/main.swift
+++ b/Sources/TranscribeCLI/main.swift
@@ -65,8 +65,6 @@ do {
     let webvttOutputFile = outputDirectory.appendingPathComponent(webvttOutputFilename)
     try Data(webvtt.utf8).write(to: webvttOutputFile)
 
-} catch let error as ArgumentParserError {
-    print(error.description)
 } catch {
     print("Error: \(error)", to: &stdError)
     exit(-1)


### PR DESCRIPTION
Fixes #1 

This adds a cli flag for the speaker names. It uses the [ArgumentParser](https://github.com/apple/swift-package-manager/blob/master/Sources/SPMUtility/ArgumentParser.swift) from the SPM Utility module.